### PR TITLE
add variable timezone to server

### DIFF
--- a/server/routes/appsRouter.ts
+++ b/server/routes/appsRouter.ts
@@ -8,7 +8,9 @@ appsRouter.use('/:appId/pages', pagesRouter);
 
 appsRouter.get(
   '/:appId/data',
+  appsController.initializeMetrics,
   appsController.setInterval,
+  appsController.setTimezone,
   appsController.retrievePages,
   appsController.retrieveOverallAvg,
   appsController.retrieveTotalTraces,

--- a/server/routes/pagesRouter.ts
+++ b/server/routes/pagesRouter.ts
@@ -1,13 +1,25 @@
 import express from 'express';
+import appsController from '../controllers/appsController';
 
-const pagesRouter = express.Router();
+// have to use mergeParams to get appId from parent router
+const pagesRouter = express.Router({ mergeParams: true });
 
-pagesRouter.get('/:pageId/data', (req, res, next) => {
-  res.status(200).send('page data retrieval controller not yet implemented');
-});
+pagesRouter.get(
+  '/:pageId/data',
+  appsController.setInterval,
+  appsController.setTimezone,
+  (req, res, next) => {
+    res.status(200).send('page data retrieval controller not yet implemented');
+  },
+);
 
-pagesRouter.get('/', (req, res, next) => {
-  res.status(200).send('page list retrieval controller not yet implemented');
-});
+pagesRouter.get(
+  '/',
+  appsController.initializeMetrics,
+  appsController.retrievePages,
+  (req, res, next) => {
+    res.status(200).send(res.locals.metrics.pages);
+  },
+);
 
 export default pagesRouter;


### PR DESCRIPTION
Linechart now uses timezone received from front-end. If no timezone provided or timezone is undefined, defaults to GMT.

Also added retrievePages middleware to GET :appId/pages

@oslabs-beta/nextview